### PR TITLE
Add Semigroup instances

### DIFF
--- a/Text/PrettyPrint/ANSI/Leijen.hs
+++ b/Text/PrettyPrint/ANSI/Leijen.hs
@@ -166,6 +166,13 @@ import System.Console.ANSI (Color(..), ColorIntensity(..), ConsoleLayer(..),
 
 import Data.String (IsString(..))
 import Data.Maybe (catMaybes)
+
+-- NB: if you import more from Data.Semigroup make sure the
+--     build-depends version range is still accurate
+-- NB2: if you consider re-exporting Semigroup((<>)) take into account
+--      that only starting with semigroup-0.8 `infixr 6 <>` was used!
+import qualified Data.Semigroup as Semi (Semigroup((<>)))
+
 #if __GLASGOW_HASKELL__ >= 710
 import Data.Monoid ((<>))
 #elif __GLASGOW_HASKELL__ >= 704
@@ -864,8 +871,11 @@ data SimpleDoc  = SFail
 -- from base gained a Monoid instance (<http://hackage.haskell.org/trac/ghc/ticket/4378>):
 instance Monoid Doc where
     mempty = empty
-    mappend = beside
+    mappend = (Semi.<>)
     mconcat = hcat
+
+instance Semi.Semigroup Doc where
+    (<>) = beside
 
 -- MCB: also added when "pretty" got the corresponding instances:
 instance IsString Doc where

--- a/ansi-wl-pprint.cabal
+++ b/ansi-wl-pprint.cabal
@@ -30,6 +30,12 @@ flag Example
 library
   exposed-modules: Text.PrettyPrint.ANSI.Leijen
   ghc-options: -Wall -fno-warn-name-shadowing -fno-warn-unused-matches
+
+  if impl(ghc >= 8.0)
+    ghc-options: -Wcompat
+  else
+    -- see also notes in Text.PrettyPrint.ANSI.Leijen
+    build-depends: semigroups >= 0.1 && < 0.19
         
   build-depends: ansi-terminal >= 0.4.0 && < 0.7
   if flag(newbase)


### PR DESCRIPTION
Without Semigroup instances it becomes rather awkward to use

```
import Data.Semigroup
```

in your code, as its `<>` then doesn't work with `Doc`s.

This also hinders packages depending on `ansi-wl-pprint` such as
`optparse-applicative` providing a seamless Data.Semigroup story.

NB: This requires a minor version bump
       (The re-export of `Data.Monoid.<>` has not been changed, to avoid requiring a major version bump; it may be desirable though to stop re-exporting `<>` at some point in the future and direct people to `Data.Semigroup` if they want a `<>` operator)
