### PR TITLE
Bump version to 0.6.8

### DIFF
--- a/ansi-wl-pprint.cabal
+++ b/ansi-wl-pprint.cabal
@@ -1,5 +1,5 @@
 name:                ansi-wl-pprint
-version:             0.6.7.3
+version:             0.6.8
 cabal-version:       >= 1.6
 category:            User Interfaces, Text
 synopsis:            The Wadler/Leijen Pretty Printer for colored ANSI terminal output


### PR DESCRIPTION
@quchen:

`trifecta` will need a release accompanying the release of ansi-wl-pprint
See https://github.com/ekmett/trifecta/pull/72

Btw, instance addition would need a minor bump, patch isn't enough.

With: `trifecta-1.7.1`:

```
src/Text/Trifecta/Instances.hs:18:10: error:
    Duplicate instance declarations:
      instance Data.Semigroup Doc
        -- Defined at src/Text/Trifecta/Instances.hs:18:10
      instance [safe] Data.Semigroup Doc
        -- Defined in ‘Text.PrettyPrint.ANSI.Leijen.Internal’
```

With this patch these compile and their test-suites pass:

### GHC-8.2.1

- criterion-1.2.1.0
- inline-c-0.6.0.2
- optparse-applicative-0.14.0.0
- test-framework-0.8.1.1
- trifecta-1.7.1 patched

### GHC-8.0.2, GHC-7.8.4 and GHC-7.5.3

*no inline-c*

- criterion-1.2.1.0
- optparse-applicative-0.14.0.0
- test-framework-0.8.1.1
- trifecta-1.7.1 patched