### PR TITLE
Fix #29 Relax upper bound for dependency on `ansi-terminal`

### DIFF
--- a/ansi-wl-pprint.cabal
+++ b/ansi-wl-pprint.cabal
@@ -46,7 +46,7 @@ library
     -- see also notes in Text.PrettyPrint.ANSI.Leijen
     build-depends: semigroups >= 0.18.5 && < 0.21
 
-  build-depends: ansi-terminal >= 0.9.1 && < 0.12
+  build-depends: ansi-terminal >= 0.9.1 && < 1.1
   build-depends: base >= 4.3 && < 5
 
   if impl(ghc >= 7.4)


### PR DESCRIPTION
`ansi-terminal-1.0` is released on Hackage.

Tested by building with Stack on Windows with snapshot:
~~~yaml
resolver: lts-20.20 # GHC 9.2.7
packages:
- .
extra-deps:
- ansi-terminal-1.0
- ansi-terminal-types-0.11.5
~~~

Also tested by building and using Stack with a dependency on `ansi-terminal-1.0` and setting `allow-newer-deps` for `ansi-wl-pprint`.